### PR TITLE
nixops: init

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: nix
-install: travis_wait nix-shell
+install: travis_wait nix-shell --no-build-output
 script: nix-shell --run "bash ci.sh"

--- a/ci.sh
+++ b/ci.sh
@@ -29,7 +29,7 @@ elif [[ "$1" == destroy ]]; then destroy; exit $? ; fi
 ## Standard run
 
 echo ">>> Building documentation..."
-nix-shell --run 'make -C ./docs html'
+nix-shell --no-build-output --run 'make -C ./docs html'
 
 echo ">>> Running nix-build..."
 nix-build

--- a/default.nix
+++ b/default.nix
@@ -2,34 +2,41 @@
 { pkgs ? import ./nix/pinned-pkgs.nix { } }:
 # { lib, callPackage, python3Packages }:
 
-with pkgs; with python3Packages; buildPythonPackage {
-  name = "repeat-aft";
+let
+  # Curry some common arguments
+  # See https://nixos.org/nix/manual/#ch-expression-language
+  callWithPy = path: deps: pkgs.callPackage path ({
+    buildPythonPackage = pkgs.python3Packages.buildPythonPackage;
+    fetchPypi = pkgs.python3Packages.fetchPypi;
+  } // deps);
+in with pkgs; with python3Packages; buildPythonPackage rec {
+  pname = "repeat";
+  version = "0.1.0";
+  name = "repeat-${version}";
+
   src = ./.;
   propagatedBuildInputs = [
-    (callPackage ./nix/deps/django-polymorphic.nix {
-      buildPythonPackage = buildPythonPackage;
-      fetchPypi = fetchPypi;
-      django = django;
-    })
-    (callPackage ./nix/deps/coreapi.nix {
-      buildPythonPackage = buildPythonPackage;
-      fetchPypi = fetchPypi;
+    (callWithPy ./nix/deps/django-polymorphic.nix {django = django;})
+    (callWithPy ./nix/deps/coreapi.nix {
       requests = requests;
       uritemplate = uritemplate;
 
-      coreschema = callPackage ./nix/deps/coreschema.nix {
-        buildPythonPackage = buildPythonPackage;
-        fetchPypi = fetchPypi;
-        jinja2 = jinja2;
-      };
-      itypes = callPackage ./nix/deps/itypes.nix {
-        buildPythonPackage = buildPythonPackage;
-        fetchPypi = fetchPypi;
-      };
+      coreschema = callWithPy ./nix/deps/coreschema.nix { jinja2 = jinja2; };
+      itypes = callWithPy ./nix/deps/itypes.nix { };
     })
     djangorestframework
-    # jsonschema
   ];
+
+  # Include static CSS files from Django REST framework and Django Admin
+  postInstall =
+    let path = pname: "lib/python3.6/site-packages/${pname}";
+    in ''
+    mkdir -p "$out/${path pname}/static/"
+    cp -r "${djangorestframework}/${path "rest_framework"}/static/rest_framework" \
+          "$out/${path pname}/static"
+    cp -r "${django}/${path "django"}/contrib/admin/static/admin"\
+          "$out/${path pname}/static"
+  '';
 
   meta = with lib; {
     homepage = https://github.com/ripeta/repeat-aft;

--- a/nix/ops/django-gunicorn-nginx.nix
+++ b/nix/ops/django-gunicorn-nginx.nix
@@ -1,0 +1,67 @@
+{
+  app,                 # Django app, packaged with buildPythonPackage
+  bash,                #
+  python3,             # TODO: remove
+  nginx,               #
+  gunicorn,            #
+  externalPort ? 80,   # nginx will listen for connections here
+  internalPort ? 8000  # gunicorn will listen for connections here
+}:
+
+let
+  # gunicorn has to have access to all the modules that our app requires
+  guni = gunicorn.overrideAttrs (oldAttrs: {
+    propagatedBuildInputs =
+      oldAttrs.propagatedBuildInputs ++ app.propagatedBuildInputs ++ [ app ];
+  });
+in {
+  environment.systemPackages = [ python3 guni ];
+  users.extraUsers = { django = { }; };
+  # TODO
+  # networking.firewall.allowedTCPPorts = [ 80 ];
+  networking.firewall.enable = false;
+
+  # nginx just passes off connections to gunicorn
+  services = {
+    nginx = {
+      enable = true;
+      httpConfig = ''
+        server {
+          listen ${toString externalPort} default_server;
+          server_name _;
+          location /static/ {
+              alias ${app}/lib/python3.6/site-packages/${app.pname}/static/;
+          }
+          location / {
+            proxy_pass http://localhost:${toString internalPort};
+          }
+        }
+      '';
+    };
+
+    openssh.enable = true;
+  };
+
+  systemd.services = {
+    repeat = {
+      enable = true;
+      description = "${app.pname}";
+      wants = [ "nginx.service" ];
+      after = [ "network.target" ];
+      serviceConfig = {
+          ExecStartPre = ''\
+            ${bash}/bin/bash -c \
+              '${app}/bin/manage.py makemigrations; \
+               ${app}/bin/manage.py migrate --run-syncdb'
+          '';
+          ExecStart = ''\
+            ${guni}/bin/gunicorn \
+              --bind 'localhost:${toString internalPort}' \
+              '${app.pname}.wsgi'
+          '';
+          Restart = "always";
+          User = "django";
+      };
+    };
+  };
+}

--- a/nix/ops/logical.nix
+++ b/nix/ops/logical.nix
@@ -4,39 +4,14 @@
   webserver =
     { config, pkgs, lib, ... }:
     let
-      pinned_pkgs = import ../pinned-pkgs.nix { pkgs = pkgs; };
-      app = pinned_pkgs.callPackage ../../default.nix { pkgs = pinned_pkgs; };
-    in
-    {
-      environment.systemPackages = [ pkgs.python3 ];
-      systemd.services = {
-        repeat = {
-          enable = true;
-          description = "repeat";
-          after = [ "network.target" ];
-          environment = { PYTHONUSERBASE = "${app}"; };
-          serviceConfig = {
-            ExecStartPre = "${pkgs.bash}/bin/bash -c '${app}/bin/manage.py makemigrations; ${app}/bin/manage.py migrate'";
-            # TODO: not the debug server!
-            ExecStart = "${pkgs.python3}/bin/python3 ${app}/bin/manage.py runserver";
-            Restart = "always";
-            User = "django";
-          };
-        };
+      pinnedPkgs = import ../pinned-pkgs.nix { pkgs = pkgs; };
+    in with pinnedPkgs;
 
-        httpd = {
-          enable = true;
-          documentRoot = "/var/www"
-        };
-      }
-
-      users.extraUsers = {
-        # django = { hashedPassword = builtins.getEnv "VM_PASSWORD"; };
-        django = { };
-      };
-
-      networking.firewall.allowedTCPPorts = [ 80 ];
-
-      services.openssh.enable = true;
+    import ./django-gunicorn-nginx.nix {
+      app = callPackage ../../default.nix { pkgs = pinnedPkgs; };
+      bash = bash;
+      python3 = python36;
+      gunicorn = python36Packages.gunicorn;
+      nginx = nginx;
     };
 }


### PR DESCRIPTION
This is a working [nixops](http://nixos.org/nixops/) configuration for deploying to a Virtualbox VM using nginx to forward to gunicorn. See the `ci.sh` file for deployment syntax.

Developing the nixops specification also forced some changes on the `default.nix` file, for the better. Namely, when built with `nix-build`, this package now contains all of the relevant static files (CSS/JS, etc) from Django REST Framework and for the Django admin interface. 