### PR TITLE
Reduce verbosity of Travis build log

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: nix
-install: travis_wait nix-shell
+install: travis_wait nix-shell --no-build-output
 script: nix-shell --run "bash ci.sh"

--- a/ci.sh
+++ b/ci.sh
@@ -29,7 +29,7 @@ elif [[ "$1" == destroy ]]; then destroy; exit $? ; fi
 ## Standard run
 
 echo ">>> Building documentation..."
-nix-shell --run 'make -C ./docs html'
+nix-shell --no-build-output --run 'make -C ./docs html'
 
 echo ">>> Running nix-build..."
 nix-build


### PR DESCRIPTION
As seen [here](https://travis-ci.org/ripeta/repeat-aft/builds/247673787?utm_source=github_status&utm_medium=notification), Travis doesn't handle super long build logs well. They're hard to look through anyway! This should increase the signal-to-noise ratio by reducing the amount logged when building packages with `nix`. 

The downside is that to diagnose errors that crop up while running `nix-shell`, we'll have to undo these changes. That being said, there's no foreseeable reason that `nix-shell` should throw an error that can't be reproduced locally. 