### PR TITLE
use collectstatic in nix build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ migrations/
 
 # nix-build files
 result
+repeat/static/
 
 # annoying osx files
 .DS_Store

--- a/default.nix
+++ b/default.nix
@@ -25,17 +25,13 @@ in with pkgs; with python3Packages; buildPythonPackage rec {
       itypes = callWithPy ./nix/deps/itypes.nix { };
     })
     djangorestframework
+    xpdf # scrape text from PDFs
   ];
 
   # Include static CSS files from Django REST framework and Django Admin
-  postInstall =
-    let path = pname: "lib/python3.6/site-packages/${pname}";
-    in ''
-    mkdir -p "$out/${path pname}/static/"
-    cp -r "${djangorestframework}/${path "rest_framework"}/static/rest_framework" \
-          "$out/${path pname}/static"
-    cp -r "${django}/${path "django"}/contrib/admin/static/admin"\
-          "$out/${path pname}/static"
+  postInstall = ''
+    python repeat/manage.py collectstatic --no-input
+    mv static/ $out/static/
   '';
 
   meta = with lib; {

--- a/nix/ops/django-gunicorn-nginx.nix
+++ b/nix/ops/django-gunicorn-nginx.nix
@@ -30,7 +30,7 @@ in {
           listen ${toString externalPort} default_server;
           server_name _;
           location /static/ {
-              alias ${app}/lib/python3.6/site-packages/${app.pname}/static/;
+              alias ${app}/static/;
           }
           location / {
             proxy_pass http://localhost:${toString internalPort};

--- a/repeat/repeat/settings.py
+++ b/repeat/repeat/settings.py
@@ -130,3 +130,6 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/1.11/howto/static-files/
 
 STATIC_URL = '/static/'
+STATIC_ROOT = 'static/'
+
+MEDIA_ROOT = os.path.join(BASE_DIR, "media")


### PR DESCRIPTION
Use Django's built-in `collectstatic` feature when packaging, rather than doing it manually. 