### PR TITLE
handle malformed PDF uploads

### DIFF
--- a/repeat/api/tests/test_models.py
+++ b/repeat/api/tests/test_models.py
@@ -8,6 +8,7 @@ import faker
 import json
 
 from . import factories
+from pdfutil import pdfutil
 from pdfutil import test_pdfutil
 
 from .. import models
@@ -64,6 +65,12 @@ class PaperTests(django.test.TestCase):
                          lorem_paper.get_text())
         self.assertEqual((test_pdfutil.LOREM_RESULT, True),
                          lorem_paper.get_text())
+
+        # Handles malformed data
+        bad_paper = factories.Paper.create(document=factory.django.FileField(
+            data=b"Not a PDF"))
+        with self.assertRaises(pdfutil.MalformedPDF):
+            bad_paper.get_text()
 
 
 def load_tests(loader, tests, ignore):

--- a/repeat/api/tests/test_views.py
+++ b/repeat/api/tests/test_views.py
@@ -7,6 +7,7 @@ import doctest
 import django.core.files.uploadedfile
 import django.test
 import factory
+import json
 
 from . import factories
 from pdfutil import test_pdfutil
@@ -36,6 +37,16 @@ class ViewTests(django.test.TestCase):
             # Extract all at once
             self.assertEqual(b'{"funding":null,"grant_id":null}',
                              c.get(paper_url).content)
+
+    def test_malformed_pdf(self):
+        """ Uploading a malformed PDF leads to an error, not a crash """
+        paper = factories.Paper.create(document=factory.django.FileField(
+            data=b""))
+        paper_url = "{}/{}".format(EXTRACT_URL, paper.unique_id)
+        c = django.test.Client()
+        # Extract all at once
+        d = json.loads(c.get(paper_url).content)
+        self.assertEqual({"error"}, set(d.keys()))
 
 
 def load_tests(loader, tests, ignore):

--- a/repeat/api/views.py
+++ b/repeat/api/views.py
@@ -13,6 +13,8 @@ from api.analysis import analysis
 from api import models
 from api import serializers
 
+from pdfutil import pdfutil
+
 # API Schema views
 # TODO: Automatically export/encode as a simple .json schema file
 # http://core-api.github.io/python-client/api-guide/codecs/
@@ -106,7 +108,10 @@ class Extract(views.APIView):
         if varpk is not None:
             _ = django.shortcuts.get_object_or_404(models.Variable, pk=varpk)
         paper = django.shortcuts.get_object_or_404(models.Paper, pk=paperpk)
-        text, _ = paper.get_text()
+        try:
+            text, _ = paper.get_text()
+        except pdfutil.MalformedPDF as e:
+            return response.Response(data={"error": e.json()})
 
         # If one is specified, return that one
         if varpk is not None:

--- a/repeat/pdfutil/test_pdfutil.py
+++ b/repeat/pdfutil/test_pdfutil.py
@@ -30,6 +30,10 @@ class PDFUtilTests(unittest.TestCase):
         self.assertEqual(BLANK_RESULT, pdfutil.pdf_to_text(BLANK))
         self.assertEqual(LOREM_RESULT, pdfutil.pdf_to_text(LOREM))
 
+        with self.assertRaises(pdfutil.MalformedPDF):
+            pdfutil.pdf_to_text(b"")
+            pdfutil.pdf_to_text(b"Not a PDF")
+
 
 def load_tests(loader, tests, ignore):
     """ Enable unittest discovery of doctests """


### PR DESCRIPTION
 * creates a custom Exception subclass
 * errors are raised in pdf_to_text and propogated through Views
 * error is returned in JSON to API client, rather than returning a 500

fixes #18